### PR TITLE
Add pinned messages

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -5,8 +5,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/MemeLabs/dggchat"
 	"github.com/awesome-gocui/gocui"
+	"github.com/mattroseman/dggchat"
 )
 
 const maxChatHistory = 10

--- a/chat.go
+++ b/chat.go
@@ -5,8 +5,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/MemeLabs/dggchat"
 	"github.com/awesome-gocui/gocui"
-	"github.com/mattroseman/dggchat"
 )
 
 const maxChatHistory = 10

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,9 @@ go 1.20
 
 require (
 	github.com/BurntSushi/toml v1.2.1
+	github.com/MemeLabs/dggchat v0.0.0-20230209070656-3366f640620e
 	github.com/awesome-gocui/gocui v0.6.0
 	github.com/gen2brain/beeep v0.0.0-20220909211152-5a9ec94374f6
-	github.com/mattroseman/dggchat v0.0.0-20230209014430-d0808fcddeba
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,9 @@ go 1.20
 
 require (
 	github.com/BurntSushi/toml v1.2.1
-	github.com/MemeLabs/dggchat v0.0.0-20201117114323-43344edb4906
 	github.com/awesome-gocui/gocui v0.6.0
 	github.com/gen2brain/beeep v0.0.0-20220909211152-5a9ec94374f6
+	github.com/mattroseman/dggchat v0.0.0-20230209014430-d0808fcddeba
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/BurntSushi/toml v1.2.1 h1:9F2/+DoOYIOksmaJFPw1tGFy1eDnIJXg+UHjuD8lTak=
 github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
+github.com/MemeLabs/dggchat v0.0.0-20230209070656-3366f640620e h1:Bl2yagvUkdpw+S6gc97w8oEYkKJdy2nfJkr94qMiZ0I=
+github.com/MemeLabs/dggchat v0.0.0-20230209070656-3366f640620e/go.mod h1:r7pnEgdWZ0QU6R0wMHxbPoEsv1xe8vJ7lCM2mfPj/cs=
 github.com/awesome-gocui/gocui v0.6.0 h1:hhDJiQC12tEsJNJ+iZBBVaSSLFYo9llFuYpQlL5JZVI=
 github.com/awesome-gocui/gocui v0.6.0/go.mod h1:1QikxFaPhe2frKeKvEwZEIGia3haiOxOUXKinrv17mA=
 github.com/awesome-gocui/termbox-go v0.0.0-20190427202837-c0aef3d18bcc h1:wGNpKcHU8Aadr9yOzsT3GEsFLS7HQu8HxQIomnekqf0=
@@ -19,8 +21,6 @@ github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/ad
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.14 h1:+xnbZSEeDbOIg5/mE6JF0w6n9duR1l3/WmbinWVwUuU=
 github.com/mattn/go-runewidth v0.0.14/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
-github.com/mattroseman/dggchat v0.0.0-20230209014430-d0808fcddeba h1:9uInV0yzvarVof2VixAJE3UTyb9D6DnYdrl+k2C0BrI=
-github.com/mattroseman/dggchat v0.0.0-20230209014430-d0808fcddeba/go.mod h1:GnXy3Du0oERrzuo3qWBXxwLAiTzbusQ7VPHyv8gLKGo=
 github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d h1:VhgPp6v9qf9Agr/56bj7Y/xa04UccTW04VP0Qed4vnQ=
 github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d/go.mod h1:YUTz3bUH2ZwIWBy3CJBeOBEugqcmXREj14T+iG/4k4U=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/BurntSushi/toml v1.2.1 h1:9F2/+DoOYIOksmaJFPw1tGFy1eDnIJXg+UHjuD8lTak=
 github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
-github.com/MemeLabs/dggchat v0.0.0-20201117114323-43344edb4906 h1:srAWLSWDRcP9tdN2MgszP1ENb3VUPBWAFYtF+Jb1jPY=
-github.com/MemeLabs/dggchat v0.0.0-20201117114323-43344edb4906/go.mod h1:r7pnEgdWZ0QU6R0wMHxbPoEsv1xe8vJ7lCM2mfPj/cs=
 github.com/awesome-gocui/gocui v0.6.0 h1:hhDJiQC12tEsJNJ+iZBBVaSSLFYo9llFuYpQlL5JZVI=
 github.com/awesome-gocui/gocui v0.6.0/go.mod h1:1QikxFaPhe2frKeKvEwZEIGia3haiOxOUXKinrv17mA=
 github.com/awesome-gocui/termbox-go v0.0.0-20190427202837-c0aef3d18bcc h1:wGNpKcHU8Aadr9yOzsT3GEsFLS7HQu8HxQIomnekqf0=
@@ -21,6 +19,8 @@ github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/ad
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.14 h1:+xnbZSEeDbOIg5/mE6JF0w6n9duR1l3/WmbinWVwUuU=
 github.com/mattn/go-runewidth v0.0.14/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
+github.com/mattroseman/dggchat v0.0.0-20230209014430-d0808fcddeba h1:9uInV0yzvarVof2VixAJE3UTyb9D6DnYdrl+k2C0BrI=
+github.com/mattroseman/dggchat v0.0.0-20230209014430-d0808fcddeba/go.mod h1:GnXy3Du0oERrzuo3qWBXxwLAiTzbusQ7VPHyv8gLKGo=
 github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d h1:VhgPp6v9qf9Agr/56bj7Y/xa04UccTW04VP0Qed4vnQ=
 github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d/go.mod h1:YUTz3bUH2ZwIWBy3CJBeOBEugqcmXREj14T+iG/4k4U=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/guiwrapper.go
+++ b/guiwrapper.go
@@ -23,10 +23,14 @@ type guimessage struct {
 	msg string
 	// TODO right now only set this when we want to modify tag/highlight/ignore/... later on... not on "system" messages; even though they technically have a sender too...
 	nick string
+	pin  bool
 }
 
 func (gw *guiwrapper) formatMessage(gm *guimessage) string {
 	formattedDate := gm.ts.Format(gw.timeformat)
+	if gm.pin {
+		formattedDate = gm.ts.Format("Jan 2, 2006 3:04PM")
+	}
 	return fmt.Sprintf("[%s]%s%s", formattedDate, gm.tag, gm.msg)
 }
 

--- a/main.go
+++ b/main.go
@@ -13,8 +13,8 @@ import (
 	"time"
 
 	"github.com/BurntSushi/toml"
+	"github.com/MemeLabs/dggchat"
 	"github.com/awesome-gocui/gocui"
-	"github.com/mattroseman/dggchat"
 )
 
 type config struct {

--- a/main.go
+++ b/main.go
@@ -13,8 +13,8 @@ import (
 	"time"
 
 	"github.com/BurntSushi/toml"
-	"github.com/MemeLabs/dggchat"
 	"github.com/awesome-gocui/gocui"
+	"github.com/mattroseman/dggchat"
 )
 
 type config struct {
@@ -165,6 +165,9 @@ func main() {
 	})
 	chat.Session.AddMessageHandler(func(m dggchat.Message, s *dggchat.Session) {
 		chat.renderMessage(m)
+	})
+	chat.Session.AddPinHandler(func(p dggchat.Pin, s *dggchat.Session) {
+		chat.renderPin(p)
 	})
 	chat.Session.AddErrorHandler(func(e string, s *dggchat.Session) {
 		chat.renderError(e)

--- a/ui.go
+++ b/ui.go
@@ -276,17 +276,7 @@ func (c *chat) renderMessage(m dggchat.Message) {
 }
 
 func (c *chat) renderPin(p dggchat.Pin) {
-	// TODO edit this function to
-	// 1. skip filters that shouldn't be applied to pins
-	// 2. color the whole message something noticeable
-	// 3. have a full date + time for the message
-
 	taggedNick := p.Sender.Nick
-
-	// don't show ignored users
-	if contains(c.config.Ignores, strings.ToLower(taggedNick)) {
-		return
-	}
 
 	var coloredNick string
 
@@ -307,16 +297,6 @@ func (c *chat) renderPin(p dggchat.Pin) {
 		}
 	}
 	switch {
-	case strings.Contains(strings.ToLower(p.Message), "nsfl"):
-		messageColor += string(fgYellow)
-		if c.config.HideNSFL {
-			formattedData = "<nsfl post hidden>"
-		}
-	case strings.Contains(strings.ToLower(p.Message), "nsfw"):
-		messageColor += string(fgRed)
-		if c.config.HideNSFW {
-			formattedData = "<nsfw post hidden>"
-		}
 	case strings.HasPrefix(p.Message, ">"):
 		messageColor += string(fgGreen)
 	case strings.HasPrefix(p.Message, "ඞ"):

--- a/ui.go
+++ b/ui.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/MemeLabs/dggchat"
 	"github.com/awesome-gocui/gocui"
 	"github.com/gen2brain/beeep"
-	"github.com/mattroseman/dggchat"
 )
 
 type color string

--- a/ui.go
+++ b/ui.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/MemeLabs/dggchat"
 	"github.com/awesome-gocui/gocui"
 	"github.com/gen2brain/beeep"
+	"github.com/mattroseman/dggchat"
 )
 
 type color string
@@ -273,6 +273,70 @@ func (c *chat) renderMessage(m dggchat.Message) {
 
 	msg := fmt.Sprintf("%s: %s", coloredNick, formattedData)
 	c.guiwrapper.addMessage(guimessage{m.Timestamp, formattedTag, msg, m.Sender.Nick})
+}
+
+func (c *chat) renderPin(p dggchat.Pin) {
+	// TODO edit this function to
+	// 1. skip filters that shouldn't be applied to pins
+	// 2. color the whole message something noticeable
+	// 3. have a full date + time for the message
+
+	taggedNick := p.Sender.Nick
+
+	// don't show ignored users
+	if contains(c.config.Ignores, strings.ToLower(taggedNick)) {
+		return
+	}
+
+	var coloredNick string
+
+	if c.isTagged(p.Sender.Nick) {
+		coloredNick = fmt.Sprintf("%s%s %s", tagMap[c.config.Tags[strings.ToLower(p.Sender.Nick)]], taggedNick, reset) // change color of username if the user is tagged
+	}
+
+	if coloredNick == "" {
+		coloredNick = fmt.Sprintf("%s%s%s", Bold, taggedNick, reset)
+	}
+
+	formattedData := p.Message
+	var messageColor string
+	if c.username != "" && strings.Contains(strings.ToLower(p.Message), strings.ToLower(c.username)) || c.isHighlighted(p.Message) {
+		messageColor = c.config.HighlightBg
+		if c.config.MsgNotify {
+			beeep.Notify("tdgg - "+p.Sender.Nick, p.Message, "")
+		}
+	}
+	switch {
+	case strings.Contains(strings.ToLower(p.Message), "nsfl"):
+		messageColor += string(fgYellow)
+		if c.config.HideNSFL {
+			formattedData = "<nsfl post hidden>"
+		}
+	case strings.Contains(strings.ToLower(p.Message), "nsfw"):
+		messageColor += string(fgRed)
+		if c.config.HideNSFW {
+			formattedData = "<nsfw post hidden>"
+		}
+	case strings.HasPrefix(p.Message, ">"):
+		messageColor += string(fgGreen)
+	case strings.HasPrefix(p.Message, "ඞ"):
+		messageColor += string(fgMagenta)
+	}
+	if messageColor == c.config.HighlightBg {
+		messageColor += c.config.HighlightFg
+	}
+	formattedData = fmt.Sprintf("%s%s%s", messageColor, formattedData, reset)
+
+	// currently not in use
+	formattedTag := "   "
+	c.config.RLock()
+	if color, ok := c.config.Tags[strings.ToLower(p.Sender.Nick)]; ok {
+		formattedTag = fmt.Sprintf("%s   %s", tagMap[color], reset)
+	}
+	c.config.RUnlock()
+
+	msg := fmt.Sprintf("%s: %s", coloredNick, formattedData)
+	c.guiwrapper.addMessage(guimessage{p.Timestamp, formattedTag, msg, p.Sender.Nick})
 }
 
 func (c *chat) renderPrivateMessage(pm dggchat.PrivateMessage) {

--- a/ui.go
+++ b/ui.go
@@ -188,7 +188,7 @@ func (c *chat) renderDebug(s interface{}) {
 func (c *chat) renderError(errorString string) {
 	tag := fmt.Sprintf(" %sX%s ", bgRed, reset)
 	msg := fmt.Sprintf("%s*Error sending message: %s*%s", fgBrightRed, errorString, reset)
-	c.guiwrapper.addMessage(guimessage{time.Now(), tag, msg, ""})
+	c.guiwrapper.addMessage(guimessage{time.Now(), tag, msg, "", false})
 }
 
 func (c *chat) isHighlighted(message string) bool {
@@ -272,7 +272,7 @@ func (c *chat) renderMessage(m dggchat.Message) {
 	// }
 
 	msg := fmt.Sprintf("%s: %s", coloredNick, formattedData)
-	c.guiwrapper.addMessage(guimessage{m.Timestamp, formattedTag, msg, m.Sender.Nick})
+	c.guiwrapper.addMessage(guimessage{m.Timestamp, formattedTag, msg, m.Sender.Nick, false})
 }
 
 func (c *chat) renderPin(p dggchat.Pin) {
@@ -336,19 +336,19 @@ func (c *chat) renderPin(p dggchat.Pin) {
 	c.config.RUnlock()
 
 	msg := fmt.Sprintf("%s: %s", coloredNick, formattedData)
-	c.guiwrapper.addMessage(guimessage{p.Timestamp, formattedTag, msg, p.Sender.Nick})
+	c.guiwrapper.addMessage(guimessage{p.Timestamp, formattedTag, msg, p.Sender.Nick, true})
 }
 
 func (c *chat) renderPrivateMessage(pm dggchat.PrivateMessage) {
 	tag := fmt.Sprintf(" %s%s*%s ", bgBlack, fgRed, reset)
 	msg := fmt.Sprintf("%s[PM <- %s] %s %s", fgBrightWhite, pm.User.Nick, pm.Message, reset)
-	c.guiwrapper.addMessage(guimessage{pm.Timestamp, tag, msg, ""})
+	c.guiwrapper.addMessage(guimessage{pm.Timestamp, tag, msg, "", false})
 }
 
 func (c *chat) renderSendPrivateMessage(nick string, message string) {
 	tag := fmt.Sprintf(" %s%s*%s ", bgBlack, fgRed, reset)
 	msg := fmt.Sprintf("%s[PM -> %s] %s %s", fgBrightWhite, nick, message, reset)
-	c.guiwrapper.addMessage(guimessage{time.Now(), tag, msg, ""})
+	c.guiwrapper.addMessage(guimessage{time.Now(), tag, msg, "", false})
 }
 
 func (c *chat) renderBroadcast(b dggchat.Broadcast) {
@@ -358,14 +358,14 @@ func (c *chat) renderBroadcast(b dggchat.Broadcast) {
 		extra = fmt.Sprintf("from %s ", b.Sender.Nick)
 	}
 	msg := fmt.Sprintf("%sBROADCAST %s: %s %s", fgBrightYellow, extra, b.Message, reset)
-	c.guiwrapper.addMessage(guimessage{b.Timestamp, tag, msg, ""})
+	c.guiwrapper.addMessage(guimessage{b.Timestamp, tag, msg, "", false})
 }
 
 func (c *chat) renderJoin(join dggchat.RoomAction) {
 	if contains(c.config.Stalks, strings.ToLower(join.User.Nick)) || c.config.ShowJoinLeave {
 		tag := fmt.Sprintf(" %s>%s ", bgGreen, reset)
 		msg := fmt.Sprintf("%s%s joined!%s", fgGreen, join.User.Nick, reset)
-		c.guiwrapper.addMessage(guimessage{join.Timestamp, tag, msg, ""})
+		c.guiwrapper.addMessage(guimessage{join.Timestamp, tag, msg, "", false})
 	}
 }
 
@@ -373,44 +373,44 @@ func (c *chat) renderQuit(quit dggchat.RoomAction) {
 	if contains(c.config.Stalks, strings.ToLower(quit.User.Nick)) || c.config.ShowJoinLeave {
 		tag := fmt.Sprintf(" %s<%s ", bgRed, reset)
 		msg := fmt.Sprintf("%s%s left.%s", fgRed, quit.User.Nick, reset)
-		c.guiwrapper.addMessage(guimessage{quit.Timestamp, tag, msg, ""})
+		c.guiwrapper.addMessage(guimessage{quit.Timestamp, tag, msg, "", false})
 	}
 }
 
 func (c *chat) renderMute(mute dggchat.Mute) {
 	tag := fmt.Sprintf(" %s!%s ", bgYellow, reset)
 	msg := fmt.Sprintf("%s%s muted by %s%s", fgYellow, mute.Target.Nick, mute.Sender.Nick, reset)
-	c.guiwrapper.addMessage(guimessage{mute.Timestamp, tag, msg, ""})
+	c.guiwrapper.addMessage(guimessage{mute.Timestamp, tag, msg, "", false})
 }
 
 func (c *chat) renderUnmute(unmute dggchat.Mute) {
 	tag := fmt.Sprintf(" %s!%s ", bgYellow, reset)
 	msg := fmt.Sprintf("%s%s unmuted by %s%s", fgYellow, unmute.Target.Nick, unmute.Sender.Nick, reset)
-	c.guiwrapper.addMessage(guimessage{unmute.Timestamp, tag, msg, ""})
+	c.guiwrapper.addMessage(guimessage{unmute.Timestamp, tag, msg, "", false})
 }
 
 func (c *chat) renderBan(ban dggchat.Ban) {
 	tag := fmt.Sprintf(" %s!%s ", bgRed, reset)
 	msg := fmt.Sprintf("%s%s banned by %s%s", fgRed, ban.Target.Nick, ban.Sender.Nick, reset)
-	c.guiwrapper.addMessage(guimessage{ban.Timestamp, tag, msg, ""})
+	c.guiwrapper.addMessage(guimessage{ban.Timestamp, tag, msg, "", false})
 }
 
 func (c *chat) renderUnban(unban dggchat.Ban) {
 	tag := fmt.Sprintf(" %s!%s ", bgRed, reset)
 	msg := fmt.Sprintf("%s%s unbanned by %s%s", fgRed, unban.Target.Nick, unban.Sender.Nick, reset)
-	c.guiwrapper.addMessage(guimessage{unban.Timestamp, tag, msg, ""})
+	c.guiwrapper.addMessage(guimessage{unban.Timestamp, tag, msg, "", false})
 }
 
 func (c *chat) renderSubOnly(so dggchat.SubOnly) {
 	tag := fmt.Sprintf(" %s$%s ", bgMagenta, reset)
 	msg := fmt.Sprintf("%s%s changed subonly mode to: %t %s", fgMagenta, so.Sender.Nick, so.Active, reset)
-	c.guiwrapper.addMessage(guimessage{so.Timestamp, tag, msg, ""})
+	c.guiwrapper.addMessage(guimessage{so.Timestamp, tag, msg, "", false})
 }
 
 func (c *chat) renderCommand(s string) {
 	tag := fmt.Sprintf(" %sI%s ", bgWhite, reset)
 	msg := fmt.Sprintf("%s%s%s", fgWhite, s, reset)
-	c.guiwrapper.addMessage(guimessage{time.Now(), tag, msg, ""})
+	c.guiwrapper.addMessage(guimessage{time.Now(), tag, msg, "", false})
 }
 
 func (c *chat) renderUsers(users []dggchat.User) {


### PR DESCRIPTION
The [dggchat library now supports](https://github.com/MemeLabs/dggchat/pull/16#event-8476140781) a handler for the `PIN` message type from the DGG websocket.

I've added a handler here which shows the pinned message when you first connect, and it should show it inline like any other message if the PIN is updated while you're already connected.

Pinned message when first joining:
<img width="1113" alt="Screen Shot 2023-02-09 at 1 52 11 PM" src="https://user-images.githubusercontent.com/6654122/217909574-0de6cb0c-ae4c-4505-b554-919187411631.png">
Pinned message when already joined:
<img width="1220" alt="Screen Shot 2023-02-09 at 1 51 27 PM" src="https://user-images.githubusercontent.com/6654122/217909631-79a61517-0131-4e9e-a999-99a64a6d0761.png">

In terms of formatting, I removed any filters (ignore, nsfw, nsfl) and I show the full date and time--regardless of the time configuration the user has set.

This is more of a POC, so if you have ideas for how the pinned message should be highlighted or formatted, Im open to changing it.
